### PR TITLE
NPM package wrongly published

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+components
+build
+node_modules


### PR DESCRIPTION
When tried use the package, got errors about missing module.

After some investigation found that project needs `.npmignore` without `/lib`, [otherwise it reads](https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package) `.gitignore` while publishing, so compiled resources were not included in the package.

BTW. while investigating this issue, found and used a nice tool - [irish-pub](https://www.npmjs.com/package/irish-pub).

