### PR TITLE
Add `jsnext:main` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "description": "Given a DOM node, return a unique CSS selector matching only that element",
   "main": "./lib/index.js",
+  "jsnext:main": "./src/index.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
This will fix my build process. Babel tries to transpile the files in `lib` which have already being transpiled. This creates corrupt bundles. Please merge and increment version number.

Thank you.