### PR TITLE
Escape colon in tag names

### DIFF
--- a/src/getTag.js
+++ b/src/getTag.js
@@ -5,5 +5,5 @@
  */
 export function getTag( el )
 {
-  return el.tagName.toLowerCase();
+  return el.tagName.toLowerCase().replace(/:/g, '\\:');
 }


### PR DESCRIPTION
This fixes an issue where the tag name includes a `:`. In this case, an exception is thrown. This solution escapes the colon so the `querySelector*` methods work again.

I have tried writing a test, but it doesn't work, because the behaviour of `jsdom` is not browser-compilant. However, it works in the browsers I have tested it in.