### PR TITLE
Return null also if id is an empty string

### DIFF
--- a/src/getID.js
+++ b/src/getID.js
@@ -7,7 +7,7 @@ export function getID( el )
 {
   const id = el.getAttribute( 'id' );
 
-  if( id !== null )
+  if( id !== null && id !== '')
   {
     return `#${id}`;
   }


### PR DESCRIPTION
Right now if an element has ID attribute specified but empty:

```html
<img src="whatever" id="" class="someclass" />
```

throws the error

```js
Uncaught DOMException: Failed to execute 'querySelectorAll' on 'Element': '#' is not a valid selector.
```

because is trying to get an element with id "#", which is not valid. This pr fixes that.