### PR TITLE
Remove invalid CSS class names

### DIFF
--- a/src/getClasses.js
+++ b/src/getClasses.js
@@ -11,10 +11,13 @@ export function getClasses( el )
     return [];
   }
 
-  try {
-    return Array.prototype.slice.call( el.classList );
-  } catch (e) {
-    let className = el.getAttribute( 'class' );
+    try {
+      let classList = Array.prototype.slice.call( el.classList )
+
+      // return only the valid CSS selectors based on RegEx
+      return classList.filter(item => !/^[a-z_-][a-z\d_-]*$/i.test( item ) ? null : item );
+    } catch (e) {
+      let className = el.getAttribute( 'class' );
 
     // remove duplicate and leading/trailing whitespaces
     className = className.trim().replace( /\s+/g, ' ' );

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -53,6 +53,24 @@ describe( 'Unique Selector Tests', () =>
     expect( uniqueSelector ).to.equal( '.cc.cx' );
   } );
 
+  it( 'Classes with invalid name', () =>
+  {
+    $( 'body' ).get( 0 ).innerHTML = ''; //Clear previous appends
+    $( 'body' ).append( '<div class="test2 ca=1 cb cc cd cx"></div><div class="test2 ca=1 cb cc cd ce"></div><div class="test2 ca=1 cb cc cd cz"></div><div class="test2 ca=1 cb cd ce cf cx"></div>' );
+    const findNode = $( 'body' ).find( '.test2' ).get( 0 );
+    const uniqueSelector = unique( findNode );
+    expect( uniqueSelector ).to.equal( '.cc.cx' );
+  } );
+
+  it( 'Classes with invalid name', () =>
+  {
+    $( 'body' ).get( 0 ).innerHTML = ''; //Clear previous appends
+    $( 'body' ).append( "<div class='test2 ca{}1 cb cc cd cx'></div><div class='test2 ca{}1 cb cc cd ce'></div><div class='test2 ca{}1 cb cc cd cz'></div><div class='test2 ca=1 cb cd ce cf cx'></div>" );
+    const findNode = $( 'body' ).find( '.test2' ).get( 0 );
+    const uniqueSelector = unique( findNode );
+    expect( uniqueSelector ).to.equal( '.cc.cx' );
+  } );
+
   it( 'Tag', () =>
   {
     $( 'body' ).get( 0 ).innerHTML = ''; //Clear previous appends


### PR DESCRIPTION
Based on the issue https://github.com/ericclemmons/unique-selector/issues/28 I decided to just remove all the invalid CSS classes name as it's based on `document.querySelectorAll`.

This way we just throw away these invalid classes before calling `querySelectorAll`.