### PR TITLE
Number only ID attribute is not allowed at chrome.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,7 @@ function getUniqueSelector( element, selectorTypes, attributesToIgnore )
       switch ( selectorType )
       {
         case 'ID' :
-        if ( Boolean( ID ) && testUniqueness( element, ID ) )
+        if ( Boolean( ID ) && !ID.match(/^#\d+/) && testUniqueness( element, ID ) )
         {
             return ID;
         }


### PR DESCRIPTION
Number only ID attribute is not allowed at chrome.

like this 
—
Uncaught DOMException: Failed to execute 'querySelectorAll' on 'Document': '#1671' is not a valid selector.
—

Fixed this issue.
