### PR TITLE
ID attribute begin with a number is not allowed at chrome.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,7 @@ function getUniqueSelector( element, selectorTypes, attributesToIgnore )
       switch ( selectorType )
       {
         case 'ID' :
-        if ( Boolean( ID ) && testUniqueness( element, ID ) )
+        if ( Boolean( ID ) && !ID.match(/^#\d+/) && testUniqueness( element, ID ) )
         {
             return ID;
         }

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -8,6 +8,25 @@ describe( 'Unique Selector Tests', () =>
 {
   jsdom( { skipWindowCheck : true } );
 
+  it( 'ID begin with a number', () =>
+  {
+    $( 'body' ).get( 0 ).innerHTML = ''; //Clear previous appends
+    $( 'body' ).append( '<div id="1234a" class="test5"></div>' );
+    const findNode = $( 'body' ).find( '.test5' ).get( 0 );
+    const uniqueSelector = unique( findNode );
+    expect( uniqueSelector ).to.equal( '.test5' );
+  } );
+
+  it( 'ID consist of numbers only', () =>
+  {
+    $( 'body' ).get( 0 ).innerHTML = ''; //Clear previous appends
+    $( 'body' ).append( '<div id="1234" class="test4"></div>' );
+    const findNode = $( 'body' ).find( '.test4' ).get( 0 );
+    const uniqueSelector = unique( findNode );
+    expect( uniqueSelector ).to.equal( '.test4' );
+  } );
+
+
   it( 'ID', () =>
   {
     $( 'body' ).get( 0 ).innerHTML = ''; //Clear previous appends


### PR DESCRIPTION
Thank you for your carefulness. I made a mistake for the detail. And I also added some tests.

"Begin with a number (include numbers only)" ID attribute is not allowed at chrome.

like this
—
Uncaught DOMException: Failed to execute 'querySelectorAll' on 'Document': '#1671' is not a valid selector.
—

Fixed this issue.