### PR TITLE
Allow #:id format

### DIFF
--- a/src/getID.js
+++ b/src/getID.js
@@ -10,7 +10,7 @@ export function getID( el )
   if( id !== null && id !== '')
   {
     // if the ID starts with a number selecting with a hash will cause a DOMException
-    return id.match(/^\d/) ? `[id="${id}"]` : '#' + id;
+    return id.match(/^\d|^\:/) ? `[id="${id}"]` : '#' + id;
   }
   return null;
 }


### PR DESCRIPTION
Currently when building a test recorder, I was trying to get unique selector of elements in gmail and I found out that gmail has lots of these type of id's (`<div id=":gp"></div>`) which gives an invalid error when going through with `unique-selector`.

` Failed to execute 'querySelectorAll' on 'Element'`